### PR TITLE
Feature tracker: full-width layout, drop churning timestamp

### DIFF
--- a/_data/grafana_feature_changes.json
+++ b/_data/grafana_feature_changes.json
@@ -1,4 +1,3 @@
 {
-  "generated_at": "2026-06-01T20:58:11Z",
   "changes": []
 }

--- a/_data/grafana_feature_flags.json
+++ b/_data/grafana_feature_flags.json
@@ -1,5 +1,4 @@
 {
-  "generated_at": "2026-06-01T20:58:11Z",
   "source_url": "https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go",
   "total": 372,
   "counts_by_stage": {

--- a/_pages/grafana-feature-tracker.html
+++ b/_pages/grafana-feature-tracker.html
@@ -4,9 +4,6 @@ permalink: /grafana-feature-tracker/
 layout: single
 classes: wide
 author_profile: false
-toc: true
-toc_label: "On this page"
-toc_sticky: true
 ---
 
 {% assign data = site.data.grafana_feature_flags %}
@@ -14,7 +11,7 @@ toc_sticky: true
 
 <p class="ff-meta">
   Source: <a href="{{ data.source_url }}">{{ data.source_url | remove: "https://github.com/" }}</a><br>
-  {{ data.total }} feature flags &middot; last updated {{ data.generated_at }} (auto-refreshed daily)
+  {{ data.total }} feature flags &middot; checked daily{% if changes and changes.size > 0 %} &middot; most recent change {{ changes[0].date }}{% endif %}
 </p>
 
 {% assign order = "GA,PublicPreview,PrivatePreview,Experimental,Deprecated" | split: "," %}

--- a/assets/css/feature-tracker.css
+++ b/assets/css/feature-tracker.css
@@ -1,4 +1,15 @@
-/* Styles for the Grafana Feature Tracker page (/grafana-feature-tracker/). */
+/* Styles for the Grafana Feature Tracker page (/grafana-feature-tracker/).
+   This file is loaded ONLY on that page (guarded include in head/custom.html),
+   so the .page override below cannot affect the home page or blog posts. */
+
+/* This page has no author-profile sidebar (author_profile: false). The theme
+   still floats .page to the inline-end at a reduced width to reserve the left
+   sidebar column, leaving an empty left band. Reclaim the full width here. */
+.wide .page {
+  float: none;
+  width: 100%;
+  padding-inline-end: 0;
+}
 
 .ff-meta { color: #6b7280; font-size: 0.85em; margin-bottom: 1em; }
 


### PR DESCRIPTION
Follow-up to #2.

- **Full-width layout:** the page has no author-profile sidebar, which left an empty left gutter (MM floats `.page` at reduced width to reserve the sidebar column). Reclaimed with a **page-scoped** `.wide .page` override in `feature-tracker.css` — that file loads only on this page (guarded include), so the **home page and blog posts keep their sidebar** (verified via local build: both still render `.sidebar` and don't reference the CSS).
- Removed the TOC (renders as an awkward stacked block in wide mode).
- Replaced the daily-churning "last updated" timestamp with the **most-recent change date** from the changelog (pairs with the engine clean-history change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)